### PR TITLE
Some styling inconsistency fixes, small logic fixes, require statements reordered for category/ logical reasons

### DIFF
--- a/bitmovin/account/account.js
+++ b/bitmovin/account/account.js
@@ -10,7 +10,6 @@ export const account = (configuration, http) => {
 
   const information = () => {
     const url = urljoin(accountBaseUrl, '/information');
-
     return get(configuration, url);
   };
 
@@ -44,6 +43,4 @@ export const account = (configuration, http) => {
   };
 };
 
-export default (configuration) => {
-  return account(configuration, http);
-};
+export default (configuration) => { return account(configuration, http); };

--- a/bitmovin/account/billing/contactDetails.js
+++ b/bitmovin/account/billing/contactDetails.js
@@ -15,7 +15,4 @@ export const contactDetails = (configuration, http) => {
   };
 };
 
-export default (configuration) => {
-  return contactDetails(configuration, http);
-};
-
+export default (configuration) => { return contactDetails(configuration, http); };

--- a/bitmovin/account/billing/invoices.js
+++ b/bitmovin/account/billing/invoices.js
@@ -48,7 +48,4 @@ export const invoices = (configuration, http) => {
   };
 };
 
-export default (configuration) => {
-  return invoices(configuration, http);
-};
-
+export default (configuration) => { return invoices(configuration, http); };

--- a/bitmovin/account/billing/statements.js
+++ b/bitmovin/account/billing/statements.js
@@ -48,7 +48,4 @@ export const statements = (configuration, http) => {
   };
 };
 
-export default (configuration) => {
-  return statements(configuration, http);
-};
-
+export default (configuration) => { return statements(configuration, http); };

--- a/bitmovin/account/organizations/groups.js
+++ b/bitmovin/account/organizations/groups.js
@@ -35,6 +35,4 @@ export const groups = (configuration, organizationId, http) => {
   return fn;
 };
 
-export default (configuration, organizationId) => {
-  return groups(configuration, organizationId, http);
-};
+export default (configuration, organizationId) => { return groups(configuration, organizationId, http); };

--- a/bitmovin/account/organizations/organizations.js
+++ b/bitmovin/account/organizations/organizations.js
@@ -37,6 +37,4 @@ export const organizations = (configuration, http) => {
   return fn;
 };
 
-export default (configuration) => {
-  return organizations(configuration, http);
-};
+export default (configuration) => { return organizations(configuration, http); };

--- a/bitmovin/account/organizations/permissions.js
+++ b/bitmovin/account/organizations/permissions.js
@@ -31,6 +31,4 @@ export const permissions = (configuration, organizationId, groupId, http) => {
   return fn;
 };
 
-export default (configuration, organizationId, groupId) => {
-  return permissions(configuration, organizationId, groupId, http);
-};
+export default (configuration, organizationId, groupId) => { return permissions(configuration, organizationId, groupId, http); };

--- a/bitmovin/account/organizations/tenants.js
+++ b/bitmovin/account/organizations/tenants.js
@@ -31,6 +31,4 @@ export const tenants = (configuration, organizationId, groupId, http) => {
   return fn;
 };
 
-export default (configuration, organizationId, groupId) => {
-  return tenants(configuration, organizationId, groupId, http);
-};
+export default (configuration, organizationId, groupId) => { return tenants(configuration, organizationId, groupId, http); };

--- a/bitmovin/analytics/domains.js
+++ b/bitmovin/analytics/domains.js
@@ -35,6 +35,4 @@ export const domains = (configuration, licenseId, http) => {
   return fn;
 };
 
-export default (configuration, licenseId) => {
-  return domains(configuration, licenseId, http);
-};
+export default (configuration, licenseId) => { return domains(configuration, licenseId, http); };

--- a/bitmovin/analytics/impressions.js
+++ b/bitmovin/analytics/impressions.js
@@ -13,6 +13,4 @@ export const impressions = (configuration, http) => {
   return fn;
 };
 
-export default (configuration) => {
-  return impressions(configuration, http);
-};
+export default (configuration) => { return impressions(configuration, http); };

--- a/bitmovin/analytics/licenses.js
+++ b/bitmovin/analytics/licenses.js
@@ -1,6 +1,5 @@
 import urljoin from 'url-join';
 import http, { utils } from '../utils/http';
-
 import domains from './domains';
 
 export const licenses = (configuration, http) => {
@@ -36,6 +35,4 @@ export const licenses = (configuration, http) => {
   return fn;
 };
 
-export default (configuration) => {
-  return licenses(configuration, http);
-};
+export default (configuration) => { return licenses(configuration, http); };

--- a/bitmovin/analytics/queries.js
+++ b/bitmovin/analytics/queries.js
@@ -17,6 +17,4 @@ export const queries = (configuration, http) => {
   return fn;
 };
 
-export default (configuration) => {
-  return queries(configuration, http);
-};
+export default (configuration) => { return queries(configuration, http); };

--- a/bitmovin/analytics/statistics.js
+++ b/bitmovin/analytics/statistics.js
@@ -12,7 +12,6 @@ export const statistics = (configuration, http) => {
       }
 
       const analyticsStatisticsBaseUrl = urljoin(configuration.apiBaseUrl, '/analytics/statistics/impressions');
-
       const getParams = utils.buildGetParamString({
         licenseKeyId,
         start,
@@ -21,8 +20,8 @@ export const statistics = (configuration, http) => {
         offset,
         limit
       });
-
       const url = urljoin(analyticsStatisticsBaseUrl, getParams);
+
       return get(configuration, url);
     },
     INTERVAL: {
@@ -31,6 +30,4 @@ export const statistics = (configuration, http) => {
   };
 };
 
-export default (configuration) => {
-  return statistics(configuration, http);
-};
+export default (configuration) => { return statistics(configuration, http); };

--- a/bitmovin/bitmovin.js
+++ b/bitmovin/bitmovin.js
@@ -1,5 +1,4 @@
 import urljoin from 'url-join';
-
 import encodings from './encoding/encodings/encodings';
 import codecConfigurations from './encoding/codecConfigurations';
 import inputs from './encoding/inputs';
@@ -16,7 +15,6 @@ import analyticsLicenses from './analytics/licenses';
 import analyticsQueries from './analytics/queries';
 import analyticsImpressions from './analytics/impressions';
 import analyticsStatistics from './analytics/statistics';
-
 import logger from './utils/Logger';
 import utils from './utils/Utils';
 

--- a/bitmovin/encoding/filters.js
+++ b/bitmovin/encoding/filters.js
@@ -10,7 +10,6 @@ export const filters = (configuration, http) => {
     let fn = (filterId) => {
       return {
         details   : () => {
-
           let url = urljoin(configuration.apiBaseUrl, 'encoding/filters', typeUrl, filterId);
 
           return new Promise((resolve, reject) => {
@@ -24,7 +23,6 @@ export const filters = (configuration, http) => {
           });
         },
         customData: () => {
-
           let url = urljoin(configuration.apiBaseUrl, 'encoding/filters', typeUrl, filterId, 'customData');
 
           return new Promise((resolve, reject) => {
@@ -38,7 +36,6 @@ export const filters = (configuration, http) => {
           });
         },
         delete    : () => {
-
           let url = urljoin(configuration.apiBaseUrl, 'encoding/filters', typeUrl, filterId);
 
           return new Promise((resolve, reject) => {

--- a/bitmovin/encoding/outputs.js
+++ b/bitmovin/encoding/outputs.js
@@ -12,7 +12,6 @@ export const outputs = (configuration, http) => {
         },
         customData: () => {
           let url = urljoin(configuration.apiBaseUrl, 'encoding/outputs', typeUrl, outputId, 'customData');
-
           return get(configuration, url);
         },
         delete    : () => {
@@ -50,7 +49,6 @@ export const outputs = (configuration, http) => {
       return {
         details: () => {
           let url = urljoin(configuration.apiBaseUrl, 'encoding/outputs', typeUrl, outputId);
-
           return get(configuration, url);
         }
       };
@@ -105,7 +103,6 @@ export const outputs = (configuration, http) => {
 
     getType: (outputId) => {
       let url = urljoin(configuration.apiBaseUrl, 'encoding/outputs', outputId, 'type');
-
       return get(configuration, url);
     }
   };

--- a/bitmovin/encoding/statistics.js
+++ b/bitmovin/encoding/statistics.js
@@ -10,7 +10,7 @@ export const statistics = (configuration, http) => {
     let newUrl = url;
     let {limit, offset} = options;
 
-    if (options !== {} && options.from && options.to) {
+    if (options && options.from && options.to) {
       if (!isValidApiRequestDateString(options.from) || !isValidApiRequestDateString(options.to)) {
         console.error('Wrong date format! Correct format is yyyy-MM-dd');
         return Promise.reject(new BitmovinError('Wrong date format! Correct format is yyyy-MM-dd', {}));
@@ -22,7 +22,6 @@ export const statistics = (configuration, http) => {
       limit: limit,
       offset: offset
     });
-
     if (getParams.length > 0) {
       newUrl = urljoin(newUrl, getParams);
     }
@@ -92,6 +91,4 @@ export const statistics = (configuration, http) => {
   };
 };
 
-export default (configuration) => {
-  return statistics(configuration, http);
-};
+export default (configuration) => { return statistics(configuration, http); };

--- a/bitmovin/player/channels.js
+++ b/bitmovin/player/channels.js
@@ -47,6 +47,4 @@ export const channels = (configuration, http) => {
   return fn;
 };
 
-export default (configuration) => {
-  return channels(configuration, http);
-};
+export default (configuration) => { return channels(configuration, http); };

--- a/bitmovin/player/domains.js
+++ b/bitmovin/player/domains.js
@@ -35,7 +35,4 @@ export const domains = (configuration, licenseId, http) => {
   return fn;
 };
 
-export default (configuration, licenseId) => {
-  return domains(configuration, licenseId, http);
-};
-// Module.exports = domains;
+export default (configuration, licenseId) => { return domains(configuration, licenseId, http); };

--- a/bitmovin/player/licenses.js
+++ b/bitmovin/player/licenses.js
@@ -1,6 +1,5 @@
 import urljoin from 'url-join';
 import http, { utils } from '../utils/http';
-
 import domains from './domains';
 import thirdPartyLicensing from './thirdPartyLicensing';
 
@@ -38,6 +37,4 @@ export const licenses = (configuration, http) => {
   return fn;
 };
 
-export default (configuration) => {
-  return licenses(configuration, http);
-};
+export default (configuration) => { return licenses(configuration, http); };

--- a/bitmovin/player/statistics.js
+++ b/bitmovin/player/statistics.js
@@ -31,6 +31,4 @@ export const statistics = (configuration, http) => {
   };
 };
 
-export default (configuration) => {
-  return statistics(configuration, http);
-};
+export default (configuration) => { return statistics(configuration, http); };

--- a/bitmovin/player/thirdPartyLicensing.js
+++ b/bitmovin/player/thirdPartyLicensing.js
@@ -20,6 +20,4 @@ export const thirdPartyLicensing = (configuration, licenseId, http) => {
   };
 };
 
-export default (configuration, licenseId) => {
-  return thirdPartyLicensing(configuration, licenseId, http);
-};
+export default (configuration, licenseId) => { return thirdPartyLicensing(configuration, licenseId, http); };

--- a/bitmovin/utils/http.js
+++ b/bitmovin/utils/http.js
@@ -83,7 +83,7 @@ const utils = {
       if (getParams.hasOwnProperty(key)) {
         let value = getParams[key];
         if (value !== undefined && value !== null && value !== '') {
-          params.push(key + '=' + getParams[key]);
+          params.push(key + '=' + value);
         }
       }
     }

--- a/examples/encoding/01_simple_encoding_dash_manifest.js
+++ b/examples/encoding/01_simple_encoding_dash_manifest.js
@@ -36,10 +36,9 @@
 
 // ---------------------------------------------------------------------------------------------------------------------
 
-const Bitmovin = require('bitmovin-javascript').default;
-console.log(Bitmovin);
 const Promise = require('bluebird');
 
+const Bitmovin = require('bitmovin-javascript').default;
 const BITMOVIN_API_KEY = '<YOUR_API_KEY>';
 const bitmovin         = new Bitmovin({'apiKey': BITMOVIN_API_KEY, debug: false});
 
@@ -189,11 +188,10 @@ const main = () => new Promise((resolve, reject) => {
       console.log('error creating streams and muxings.');
       reject(error);
     });
-  });
+  })
 });
 
 const addStreamToEncoding = (input, output, codecConfiguration, encoding) => {
-
   const inputStream = {
     inputId: input.id,
     inputPath: INPUT_FILE_PATH,
@@ -333,7 +331,6 @@ const waitUntilHlsManifestFinished = (manifest) => {
 const createHlsManifest = (output, encoding, audioMuxingsWithPath, videoMuxingsWithPath) => {
   return new Promise((resolve, reject) => {
     const mediaPromises = [];
-
 
     createHlsManifestResource(output).then((createdHlsManifest) => {
       let audioPromise;

--- a/examples/encoding/02_simple_encoding_dash_cenc_hls_fairplay.js
+++ b/examples/encoding/02_simple_encoding_dash_cenc_hls_fairplay.js
@@ -1,9 +1,8 @@
 // 02_simple_encoding_dash_cenc_hls_fairplay.js
 
 const Promise = require('bluebird');
+
 const Bitmovin = require('bitmovin-javascript').default;
-
-
 const BITMOVIN_API_KEY = '';
 const bitmovin = new Bitmovin({apiKey: BITMOVIN_API_KEY, debug: true});
 
@@ -30,7 +29,6 @@ const DRM_FAIRPLAY_URI = '';
 
 const main = () => {
   return new Promise((resolve, reject) => {
-
     const httpInputCreationPromise = createInput();
     const s3OutputCreationPromise = createOutput();
     const encodingResourceCreationPromise = createEncoding();

--- a/examples/encoding/03_start_livestream_dash_hls.js
+++ b/examples/encoding/03_start_livestream_dash_hls.js
@@ -1,8 +1,8 @@
 // 03_start_livestream_dash_hls.js
 
 const Promise = require('bluebird');
-const Bitmovin = require('bitmovin-javascript').default;
 
+const Bitmovin = require('bitmovin-javascript').default;
 const BITMOVIN_API_KEY = 'INSERT_YOUR_API_KEY';
 const bitmovin = new Bitmovin({apiKey: BITMOVIN_API_KEY});
 
@@ -36,7 +36,6 @@ const LIVE_ENCODING_DETAILS_POLLING_INTERVAL = 10000;
 
 const main = () => {
   return new Promise((resolve, reject) => {
-
     const rtmpInputPromise = getRtmpInput();
     const s3OutputCreationPromise = createOutput();
     const encodingResourceCreationPromise = createEncoding();
@@ -59,14 +58,14 @@ const main = () => {
       ]
     ).then(
       ([
-              input,
-              output,
-              encoding,
-              codecConfigurationH264At1080p,
-              codecConfigurationH264At720p,
-              codecConfigurationH264At480p,
-              codecConfigurationH264At360p,
-              codecConfigurationAAC
+        input,
+        output,
+        encoding,
+        codecConfigurationH264At1080p,
+        codecConfigurationH264At720p,
+        codecConfigurationH264At480p,
+        codecConfigurationH264At360p,
+        codecConfigurationAAC
        ]) => {
         console.log('Successfully created input, output and codec configurations.');
         const dashManifestCreationPromise = createDashManifestWithPeriodAndAdaptationSets(output.id);
@@ -180,9 +179,8 @@ const main = () => {
   });
 };
 
-/*
- ENCODING
- */
+// ENCODING
+
 const createEncoding = () => {
   return new Promise((resolve, reject) => {
     const encoding = {
@@ -232,9 +230,8 @@ const createStreamsAndMuxings = (encoding, streamDefinitions, output, input) => 
   });
 };
 
-/*
- INPUT
- */
+// INPUT
+
 const getRtmpInput = () => {
   return new Promise((resolve, reject) => {
     bitmovin.encoding.inputs.rtmp.list().then((response) => {
@@ -246,9 +243,8 @@ const getRtmpInput = () => {
   });
 };
 
-/*
- OUTPUT
- */
+// OUTPUT
+
 const createOutput = () => {
   return new Promise((resolve, reject) => {
     const gcsOutput = {
@@ -265,9 +261,8 @@ const createOutput = () => {
   });
 };
 
-/*
- CODEC CONFIGURATION
- */
+// CODEC CONFIGURATION
+
 const createH264CodecConfiguration = (width, height, bitrate, fps) => {
   return new Promise((resolve, reject) => {
     const h264CodecConfiguration = {
@@ -299,9 +294,8 @@ const createAACCodecConfiguration = (bitrate, rate) => {
   });
 };
 
-/*
- STREAMS
- */
+// STREAMS
+
 const createStream = (encoding, streamDefinition, input) => {
   const stream = {
     name: 'Stream with ' + streamDefinition.codecConfiguration.name,
@@ -317,9 +311,8 @@ const createStream = (encoding, streamDefinition, input) => {
   return bitmovin.encoding.encodings(encoding.id).streams.add(stream);
 };
 
-/*
- MUXINGS
- */
+// MUXINGS
+
 const createFmp4MuxingsForStreams = (encoding, streams, output, streamDefinitions) => {
   return Promise.map(streams, (stream, index) => {
     return addFmp4MuxingToStream(encoding, stream, output, streamDefinitions[index].dashSegmentsPath);
@@ -373,9 +366,8 @@ const addTsMuxingForStream = (encoding, stream, output, outputPrefix) => {
   return bitmovin.encoding.encodings(encoding.id).muxings.ts.add(tsMuxing);
 };
 
-/*
- MANIFESTS
- */
+// MANIFESTS
+
 const createDashManifestWithPeriodAndAdaptationSets = (outputId) => {
   return new Promise((resolve, reject) => {
     const dashManifest = {
@@ -500,9 +492,8 @@ const createHlsVideoVariantStream = (manifest, audioGroupId, segmentPath, uri, e
   return bitmovin.encoding.manifests.hls(manifest.id).streams.add(variantStream);
 };
 
-/*
- ENCODING CONTROL
- */
+// ENCODING CONTROL
+
 const startLiveEncoding = (encoding, liveConfiguration) => {
   return bitmovin.encoding.encodings(encoding.id).startLive(liveConfiguration);
 };

--- a/examples/encoding/04_stop_livestream.js
+++ b/examples/encoding/04_stop_livestream.js
@@ -1,11 +1,10 @@
 // 04_stop_livestream.js
 
 const Bitmovin = require('bitmovin-javascript').default;
-
 const BITMOVIN_API_KEY = 'INSERT_YOUR_API_KEY';
-const ENCODING_ID_TO_STOP = 'ENCODING ID TO STOP';
-
 const bitmovin = new Bitmovin({apiKey: BITMOVIN_API_KEY});
+
+const ENCODING_ID_TO_STOP = 'ENCODING ID TO STOP';
 
 const main = () => {
   return bitmovin.encoding.encodings(ENCODING_ID_TO_STOP).stopLive();

--- a/examples/encoding/05_live_to_vod_hls_manifest.js
+++ b/examples/encoding/05_live_to_vod_hls_manifest.js
@@ -1,8 +1,8 @@
 // 05_live_to_vod_hls_manifest
 
-const Bitmovin = require('bitmovin-javascript').default;
 const Promise = require('bluebird');
 
+const Bitmovin = require('bitmovin-javascript').default;
 const BITMOVIN_API_KEY = 'YOUR_API_KEY';
 const bitmovin         = new Bitmovin({'apiKey': BITMOVIN_API_KEY});
 
@@ -133,9 +133,8 @@ const getVideoManifestInfos = (encodingId, muxings) => {
   });
 };
 
-/*
- MANIFESTS
- */
+// MANIFESTS
+
 const createHlsManifest = (outputId) => {
   return new Promise((resolve, reject) => {
     const hlsManifest = {

--- a/examples/encoding/06_live_to_vod_dash_manifest.js
+++ b/examples/encoding/06_live_to_vod_dash_manifest.js
@@ -1,8 +1,8 @@
 // 06_live_to_vod_dash_manifest
 
-const Bitmovin = require('bitmovin-javascript').default;
 const Promise = require('bluebird');
 
+const Bitmovin = require('bitmovin-javascript').default;
 const BITMOVIN_API_KEY = 'YOUR_API_KEY';
 const bitmovin         = new Bitmovin({'apiKey': BITMOVIN_API_KEY});
 
@@ -138,9 +138,8 @@ const getVideoManifestInfos = (encodingId, muxings) => {
   });
 };
 
-/*
- MANIFESTS
- */
+// MANIFESTS
+
 const createDashManifestWithPeriodAndAdaptationSets = (outputId) => {
   return new Promise((resolve, reject) => {
     const dashManifest = {

--- a/examples/encoding/07_encoding_dash_hls_thumbnail.js
+++ b/examples/encoding/07_encoding_dash_hls_thumbnail.js
@@ -1,9 +1,8 @@
 // 07_encoding_dash_hls_thumbnail.js
 
-const Bitmovin = require('bitmovin-javascript').default;
-console.log(Bitmovin);
 const Promise = require('bluebird');
 
+const Bitmovin = require('bitmovin-javascript').default;
 const BITMOVIN_API_KEY = '<INSERT_YOUR_API_CODE>';
 const bitmovin         = new Bitmovin({'apiKey': BITMOVIN_API_KEY, debug: false});
 
@@ -37,19 +36,19 @@ console.log('OUTPUT_PATH', OUTPUT_PATH);
 const s3Input = {
   name       :  'Sample Input',
   description:  'This is a demo s3 input',
-  accessKey:    S3_ACCESS_KEY,
-  secretKey:    S3_SECRET_KEY,
-  bucketName:   S3_BUCKET_NAME,
+  accessKey  :  S3_ACCESS_KEY,
+  secretKey  :  S3_SECRET_KEY,
+  bucketName :  S3_BUCKET_NAME,
   cloudRegion:  S3_CLOUD_REGION
 };
 
 const ftpOutput = {
-  name       :              'FTP Output',
-  description:              'This is a demo FTP output',
-  host:                     FTP_HOST,
-  username:                 FTP_USER,
-  password:                 FTP_PASSWORD,
-  transferVersion:          FTP_TRANSFER_VERSION,
+  name                    : 'FTP Output',
+  description             : 'This is a demo FTP output',
+  host                    : FTP_HOST,
+  username                : FTP_USER,
+  password                : FTP_PASSWORD,
+  transferVersion         : FTP_TRANSFER_VERSION,
   maxConcurrentConnections: FTP_MAX_CONCURRENT_CONNECTIONS
 };
 
@@ -90,22 +89,21 @@ const h264VideoCodecConfiguration240p = {
 };
 
 const encodingResource = {
-  name: ENCODING_NAME,
-  description: 'bitmovin-javascript api client test encoding',
+  name          : ENCODING_NAME,
+  description   : 'bitmovin-javascript api client test encoding',
   encoderVersion: 'STABLE'
 };
 
 const thumbnailResource = {
-  name: 'My Thumbnail',
+  name       : 'My Thumbnail',
   description: 'Demo thumbnail',
-  height: 320,
-  unit: 'SECONDS',
-  positions: THUMBNAIL_POSITIONS,
-  pattern: 'thumbnail-%number%.png'
+  height     : 320,
+  unit       : 'SECONDS',
+  positions  : THUMBNAIL_POSITIONS,
+  pattern    : 'thumbnail-%number%.png'
 };
 
 const main = () => new Promise((resolve, reject) => {
-
   let aacCodecConfiguration = Object.assign({}, aacAudioCodecConfiguration);
   let h264CodecConfiguration720p = Object.assign({}, h264VideoCodecConfiguration720p);
   let h264CodecConfiguration480p = Object.assign({}, h264VideoCodecConfiguration480p);
@@ -260,15 +258,14 @@ const main = () => new Promise((resolve, reject) => {
 });
 
 const addStreamToEncoding = (input, output, codecConfiguration, encoding) => {
-
   const inputStream = {
-    inputId: input.id,
-    inputPath: INPUT_FILE_PATH,
+    inputId      : input.id,
+    inputPath    : INPUT_FILE_PATH,
     selectionMode: 'AUTO'
   };
 
   let stream = {
-    inputStreams: [inputStream],
+    inputStreams : [inputStream],
     codecConfigId: codecConfiguration.id
   };
 
@@ -401,7 +398,7 @@ const createThumbnail = (output, encoding, stream, thumbnail) => {
   let thumbnailRequest = Object.assign({}, thumbnail, {
     outputs: [
       {
-        outputId: output.id,
+        outputId  : output.id,
         outputPath: THUMBNAIL_OUTPUT_PATH
       }
     ]
@@ -422,14 +419,14 @@ const createHlsManifest = (output, encoding, audioMuxingsWithPath, videoMuxingsW
           const path = audioMuxingWithPath.path;
 
           const audioMedia = {
-            groupId: 'audio_group',
-            name: 'Audio media ' + tsMuxing.name,
+            groupId    : 'audio_group',
+            name       : 'Audio media ' + tsMuxing.name,
             segmentPath: path,
-            encodingId: encoding.id,
-            muxingId: tsMuxing.id,
-            streamId: audioMuxingWithPath.streamId,
-            language: 'en',
-            uri: 'videomedia.m3u8'
+            encodingId : encoding.id,
+            muxingId   : tsMuxing.id,
+            streamId   : audioMuxingWithPath.streamId,
+            language   : 'en',
+            uri        : 'videomedia.m3u8'
           };
           return bitmovin.encoding.manifests.hls(createdHlsManifest.id).media.audio.add(audioMedia);
         });
@@ -451,13 +448,13 @@ const createHlsManifest = (output, encoding, audioMuxingsWithPath, videoMuxingsW
             const uri = 'video_' + videoMuxingWithPath.path.split('/')[videoMuxingWithPath.path.split('/').length-2] + '.m3u8';
 
             const variantStream = {
-              audio: audio_group,
+              audio         : audio_group,
               closedCaptions: 'NONE',
-              segmentPath: videoMuxingWithPath.path,
-              uri: uri,
-              encodingId: encoding.id,
-              streamId: videoMuxingWithPath.streamId,
-              muxingId: videoMuxingWithPath.tsMuxing.id
+              segmentPath   : videoMuxingWithPath.path,
+              uri           : uri,
+              encodingId    : encoding.id,
+              streamId      : videoMuxingWithPath.streamId,
+              muxingId      : videoMuxingWithPath.tsMuxing.id
             };
 
             return bitmovin.encoding.manifests.hls(createdHlsManifest.id).streams.add(variantStream);
@@ -517,9 +514,9 @@ const createDashManifest = (output, encoding, audioMuxingsWithPath, videoMuxings
             const path = muxingWithPath.path;
 
             const fmp4Representation = {
-              type: 'TEMPLATE',
-              encodingId: encoding.id,
-              muxingId: fmp4Muxing.id,
+              type       : 'TEMPLATE',
+              encodingId : encoding.id,
+              muxingId   : fmp4Muxing.id,
               segmentPath: path
             };
             return bitmovin.encoding.manifests.dash(createdManifest.id).periods(createdPeriod.id)
@@ -531,9 +528,9 @@ const createDashManifest = (output, encoding, audioMuxingsWithPath, videoMuxings
               const path = muxingWithPath.path;
 
               const fmp4Representation = {
-                type: 'TEMPLATE',
-                encodingId: encoding.id,
-                muxingId: fmp4Muxing.id,
+                type       : 'TEMPLATE',
+                encodingId : encoding.id,
+                muxingId   : fmp4Muxing.id,
                 segmentPath: path
               };
 
@@ -625,8 +622,8 @@ const addStream = (encoding, stream, output, codecConfiguration) => {
         addTsMuxingForStream(encoding, addedStream, output, prefix).then((addedTsMuxing) => {
           const muxingWithPath = {
             fmp4Muxing: addedFmp4Muxing,
-            tsMuxing: addedTsMuxing,
-            path: prefix
+            tsMuxing  : addedTsMuxing,
+            path      : prefix
           };
           resolve([addedStream, muxingWithPath])
         });

--- a/examples/encoding/08_encoding_hls_aes128.js
+++ b/examples/encoding/08_encoding_hls_aes128.js
@@ -1,9 +1,8 @@
 // 08_encoding_hls_aes128.js
 
 const Promise = require('bluebird');
+
 const Bitmovin = require('bitmovin-javascript').default;
-
-
 const BITMOVIN_API_KEY = '<INSERT_YOUR_API_KEY>';
 const bitmovin = new Bitmovin({apiKey: BITMOVIN_API_KEY, debug: true});
 
@@ -25,7 +24,6 @@ const DRM_AES_IV = '<YOUR_AES_IV>';
 
 const main = () => {
   return new Promise((resolve, reject) => {
-
     const s3InputCreationPromise = createInput();
     const s3OutputCreationPromise = createOutput();
     const encodingResourceCreationPromise = createEncoding();
@@ -109,11 +107,11 @@ const main = () => {
 const createInput = () => {
   return new Promise((resolve, reject) => {
     const s3Input = {
-      name: 'My awesome S3 Input',
+      name       : 'My awesome S3 Input',
       description: 'Little description for my awesome S3 Input',
-      accessKey: INPUT_S3_ACCESS_KEY,
-      secretKey: INPUT_S3_SECRET_KEY,
-      bucketName: INPUT_S3_BUCKET_NAME
+      accessKey  : INPUT_S3_ACCESS_KEY,
+      secretKey  : INPUT_S3_SECRET_KEY,
+      bucketName : INPUT_S3_BUCKET_NAME
     };
     bitmovin.encoding.inputs.s3.create(s3Input).then((createdInput) => {
       console.log('Successfully created S3 Input.', createdInput);
@@ -125,11 +123,11 @@ const createInput = () => {
 const createOutput = () => {
   return new Promise((resolve, reject) => {
     const s3Output = {
-      name: 'My awesome S3 Output',
+      name       : 'My awesome S3 Output',
       description: 'Little description for my awesome S3 Output',
-      accessKey: OUTPUT_S3_ACCESS_KEY,
-      secretKey: OUTPUT_S3_SECRET_KEY,
-      bucketName: OUTPUT_S3_BUCKET_NAME
+      accessKey  : OUTPUT_S3_ACCESS_KEY,
+      secretKey  : OUTPUT_S3_SECRET_KEY,
+      bucketName : OUTPUT_S3_BUCKET_NAME
     };
     bitmovin.encoding.outputs.s3.create(s3Output).then((createdOutput) => {
       console.log('Successfully created S3 Output.', createdOutput);
@@ -153,12 +151,12 @@ const createEncoding = () => {
 const createH264CodecConfiguration = (width, height, bitrate, fps) => {
   return new Promise((resolve, reject) => {
     const h264CodecConfiguration = {
-      name: 'H264 ' + height,
+      name   : 'H264 ' + height,
       bitrate: bitrate,
-      rate: fps,
+      rate   : fps,
       profile: 'HIGH',
-      width: width,
-      height: height
+      width  : width,
+      height : height
     };
     bitmovin.encoding.codecConfigurations.h264.create(h264CodecConfiguration).then((createdCodecConfiguration) => {
       console.log('Successfully created H264 Codec Configuration.', createdCodecConfiguration);
@@ -170,9 +168,9 @@ const createH264CodecConfiguration = (width, height, bitrate, fps) => {
 const createAACCodecConfiguration = (bitrate, rate) => {
   return new Promise((resolve, reject) => {
     const aacCodecConfiguration = {
-      name: 'English',
+      name   : 'English',
       bitrate: bitrate,
-      rate: rate
+      rate   : rate
     };
     bitmovin.encoding.codecConfigurations.aac.create(aacCodecConfiguration).then((createdCodecConfiguration) => {
       console.log('Successfully created AAC Codec Configuration.', createdCodecConfiguration);
@@ -299,15 +297,15 @@ const createHlsManifestRepresentation = (encoding, stream_ , tsMuxing, fairPlayD
 const createHlsAudioMedia = (encoding, stream_, tsMuxing, fairPlayDrm, hlsManifest, segmentPath) => {
   return new Promise((resolve, reject) => {
     const audioMedia = {
-      name: 'HLS Audio Media',
-      groupId: 'audio_group',
+      name       : 'HLS Audio Media',
+      groupId    : 'audio_group',
       segmentPath: segmentPath,
-      encodingId: encoding.id,
-      streamId: stream_.id,
-      muxingId: tsMuxing.id,
-      drmId: fairPlayDrm.id,
-      language: 'en',
-      uri: 'audio_media.m3u8'
+      encodingId : encoding.id,
+      streamId   : stream_.id,
+      muxingId   : tsMuxing.id,
+      drmId      : fairPlayDrm.id,
+      language   : 'en',
+      uri        : 'audio_media.m3u8'
     };
 
     bitmovin.encoding.manifests.hls(hlsManifest.id).media.audio.add(audioMedia).then((createdAudioMedia) => {
@@ -320,14 +318,14 @@ const createHlsAudioMedia = (encoding, stream_, tsMuxing, fairPlayDrm, hlsManife
 const createHlsVariantStream = (encoding, stream_, tsMuxing, fairPlayDrm, hlsManifest, segmentPath) => {
   return new Promise((resolve, reject) => {
     const variantStream = {
-      audio: 'audio_group',
+      audio         : 'audio_group',
       closedCaptions: 'NONE',
-      segmentPath: segmentPath,
-      encodingId: encoding.id,
-      streamId: stream_.id,
-      muxingId: tsMuxing.id,
-      drmId: fairPlayDrm.id,
-      uri: fairPlayDrm.id + '.m3u8'
+      segmentPath   : segmentPath,
+      encodingId    : encoding.id,
+      streamId      : stream_.id,
+      muxingId      : tsMuxing.id,
+      drmId         : fairPlayDrm.id,
+      uri           : fairPlayDrm.id + '.m3u8'
     };
 
     bitmovin.encoding.manifests.hls(hlsManifest.id).streams.add(variantStream).then((createdVariantStream) => {

--- a/examples/encoding/09_simple_encoding_mp4.js
+++ b/examples/encoding/09_simple_encoding_mp4.js
@@ -2,9 +2,9 @@
 
 // ---------------------------------------------------------------------------------------------------------------------
 
-const Bitmovin = require('bitmovin-javascript').default;
 const Promise = require('bluebird');
 
+const Bitmovin = require('bitmovin-javascript').default;
 const BITMOVIN_API_KEY = '<INSERT_YOUR_API_KEY>';
 const bitmovin         = new Bitmovin({'apiKey': BITMOVIN_API_KEY, debug: false});
 
@@ -182,13 +182,13 @@ const main = () => new Promise((resolve, reject) => {
 
 const addAudioStreamToEncoding = (input, output, audioCodecConfiguration, encoding) => {
   const inputStream = {
-    inputId: input.id,
-    inputPath: INPUT_FILE_PATH,
+    inputId      : input.id,
+    inputPath    : INPUT_FILE_PATH,
     selectionMode: 'AUTO'
   };
 
   let stream = {
-    inputStreams: [inputStream],
+    inputStreams : [inputStream],
     codecConfigId: audioCodecConfiguration.id
   };
 
@@ -205,13 +205,13 @@ const addAudioStreamToEncoding = (input, output, audioCodecConfiguration, encodi
 
 const addVideoStreamToEncoding = (input, output, videoCodecConfig, audioStream, encoding) => {
   const inputStream = {
-    inputId: input.id,
-    inputPath: INPUT_FILE_PATH,
+    inputId      : input.id,
+    inputPath    : INPUT_FILE_PATH,
     selectionMode: 'AUTO'
   };
 
   let videoStream = {
-    inputStreams: [inputStream],
+    inputStreams : [inputStream],
     codecConfigId: videoCodecConfig.id
   };
 

--- a/examples/encoding/10_encoding_hls_aes128_subtitle.js
+++ b/examples/encoding/10_encoding_hls_aes128_subtitle.js
@@ -1,9 +1,8 @@
 // 08_encoding_hls_aes128.js
 
 const Promise = require('bluebird');
+
 const Bitmovin = require('bitmovin-javascript').default;
-
-
 const BITMOVIN_API_KEY = '<INSERT_YOUR_API_KEY>';
 const bitmovin = new Bitmovin({apiKey: BITMOVIN_API_KEY, debug: true});
 
@@ -26,7 +25,6 @@ const VTT_MEDIA_URL = '<YOUR_VTT_MEDIA_URL>';
 
 const main = () => {
   return new Promise((resolve, reject) => {
-
     const s3InputCreationPromise = createInput();
     const s3OutputCreationPromise = createOutput();
     const encodingResourceCreationPromise = createEncoding();
@@ -113,11 +111,11 @@ const main = () => {
 const createInput = () => {
   return new Promise((resolve, reject) => {
     const s3Input = {
-      name: 'My awesome S3 Input',
+      name       : 'My awesome S3 Input',
       description: 'Little description for my awesome S3 Input',
-      accessKey: INPUT_S3_ACCESS_KEY,
-      secretKey: INPUT_S3_SECRET_KEY,
-      bucketName: INPUT_S3_BUCKET_NAME
+      accessKey  : INPUT_S3_ACCESS_KEY,
+      secretKey  : INPUT_S3_SECRET_KEY,
+      bucketName : INPUT_S3_BUCKET_NAME
     };
     bitmovin.encoding.inputs.s3.create(s3Input).then((createdInput) => {
       console.log('Successfully created S3 Input.', createdInput);
@@ -129,11 +127,11 @@ const createInput = () => {
 const createOutput = () => {
   return new Promise((resolve, reject) => {
     const s3Output = {
-      name: 'My awesome S3 Output',
+      name       : 'My awesome S3 Output',
       description: 'Little description for my awesome S3 Output',
-      accessKey: OUTPUT_S3_ACCESS_KEY,
-      secretKey: OUTPUT_S3_SECRET_KEY,
-      bucketName: OUTPUT_S3_BUCKET_NAME
+      accessKey  : OUTPUT_S3_ACCESS_KEY,
+      secretKey  : OUTPUT_S3_SECRET_KEY,
+      bucketName : OUTPUT_S3_BUCKET_NAME
     };
     bitmovin.encoding.outputs.s3.create(s3Output).then((createdOutput) => {
       console.log('Successfully created S3 Output.', createdOutput);
@@ -157,12 +155,12 @@ const createEncoding = () => {
 const createH264CodecConfiguration = (width, height, bitrate, fps) => {
   return new Promise((resolve, reject) => {
     const h264CodecConfiguration = {
-      name: 'H264 ' + height,
+      name   : 'H264 ' + height,
       bitrate: bitrate,
-      rate: fps,
+      rate   : fps,
       profile: 'HIGH',
-      width: width,
-      height: height
+      width  : width,
+      height : height
     };
     bitmovin.encoding.codecConfigurations.h264.create(h264CodecConfiguration).then((createdCodecConfiguration) => {
       console.log('Successfully created H264 Codec Configuration.', createdCodecConfiguration);
@@ -174,9 +172,9 @@ const createH264CodecConfiguration = (width, height, bitrate, fps) => {
 const createAACCodecConfiguration = (bitrate, rate) => {
   return new Promise((resolve, reject) => {
     const aacCodecConfiguration = {
-      name: 'English',
+      name   : 'English',
       bitrate: bitrate,
-      rate: rate
+      rate   : rate
     };
     bitmovin.encoding.codecConfigurations.aac.create(aacCodecConfiguration).then((createdCodecConfiguration) => {
       console.log('Successfully created AAC Codec Configuration.', createdCodecConfiguration);
@@ -303,11 +301,11 @@ const createHlsManifestRepresentation = (encoding, stream_ , tsMuxing, fairPlayD
 const createHlsVttMedia = (hlsManifest, vttUrl) => {
   return new Promise((resolve, reject) => {
     const vttMedia = {
-      name: 'HLS Vtt Media',
-      groupId: 'subtitles_group',
+      name    : 'HLS Vtt Media',
+      groupId : 'subtitles_group',
       language: 'en',
       vttUrl,
-      uri: 'vtt_media.m3u8'
+      uri     : 'vtt_media.m3u8'
     };
 
     bitmovin.encoding.manifests.hls(hlsManifest.id).media.vtt.add(vttMedia).then((createdVttMedia) => {
@@ -320,15 +318,15 @@ const createHlsVttMedia = (hlsManifest, vttUrl) => {
 const createHlsAudioMedia = (encoding, stream_, tsMuxing, fairPlayDrm, hlsManifest, segmentPath) => {
   return new Promise((resolve, reject) => {
     const audioMedia = {
-      name: 'HLS Audio Media',
-      groupId: 'audio_group',
+      name       : 'HLS Audio Media',
+      groupId    : 'audio_group',
       segmentPath: segmentPath,
-      encodingId: encoding.id,
-      streamId: stream_.id,
-      muxingId: tsMuxing.id,
-      drmId: fairPlayDrm.id,
-      language: 'en',
-      uri: 'audio_media.m3u8'
+      encodingId : encoding.id,
+      streamId   : stream_.id,
+      muxingId   : tsMuxing.id,
+      drmId      : fairPlayDrm.id,
+      language   : 'en',
+      uri        : 'audio_media.m3u8'
     };
 
     bitmovin.encoding.manifests.hls(hlsManifest.id).media.audio.add(audioMedia).then((createdAudioMedia) => {
@@ -340,15 +338,15 @@ const createHlsAudioMedia = (encoding, stream_, tsMuxing, fairPlayDrm, hlsManife
 const createHlsVariantStream = (encoding, stream_, tsMuxing, fairPlayDrm, hlsManifest, segmentPath) => {
   return new Promise((resolve, reject) => {
     const variantStream = {
-      audio: 'audio_group',
-      subtitles: 'subtitles_group',
+      audio         : 'audio_group',
+      subtitles     : 'subtitles_group',
       closedCaptions: 'NONE',
-      segmentPath: segmentPath,
-      encodingId: encoding.id,
-      streamId: stream_.id,
-      muxingId: tsMuxing.id,
-      drmId: fairPlayDrm.id,
-      uri: fairPlayDrm.id + '.m3u8'
+      segmentPath   : segmentPath,
+      encodingId    : encoding.id,
+      streamId      : stream_.id,
+      muxingId      : tsMuxing.id,
+      drmId         : fairPlayDrm.id,
+      uri           : fairPlayDrm.id + '.m3u8'
     };
 
     bitmovin.encoding.manifests.hls(hlsManifest.id).streams.add(variantStream).then((createdVariantStream) => {

--- a/examples/encoding/11_simple_encoding_mp4_smooth_manifest.js
+++ b/examples/encoding/11_simple_encoding_mp4_smooth_manifest.js
@@ -1,6 +1,6 @@
-const Bitmovin = require('bitmovin-javascript').default;
 const Promise = require('bluebird');
 
+const Bitmovin = require('bitmovin-javascript').default;
 const BITMOVIN_API_KEY = '<INSERT_YOUR_API_KEY>';
 const bitmovin         = new Bitmovin({'apiKey': BITMOVIN_API_KEY, debug: false});
 
@@ -220,14 +220,14 @@ const main = () => {
 
 const addStreamToEncoding = (input, output, streamConfig, index, codecConfiguration, encoding) => {
   const inputStream = {
-    inputId: input.id,
-    inputPath: INPUT_FILE_PATH,
+    inputId      : input.id,
+    inputPath    : INPUT_FILE_PATH,
     selectionMode: streamConfig.selectionMode,
-    position: streamConfig.position
+    position     : streamConfig.position
   };
 
   let stream = {
-    inputStreams: [inputStream],
+    inputStreams : [inputStream],
     codecConfigId: codecConfiguration.id
   };
 
@@ -326,10 +326,10 @@ const createSmoothManifest = (output, encoding, audioMuxingsWithPath, videoMuxin
 
         const smoothRepresentation = {
           encodingId: encoding.id,
-          muxingId: mp4Muxing.id,
-          mediaFile: mp4Muxing.filename,
-          trackName: (mp4Muxing.filename.startsWith('audio') ? muxingWithPath.trackName : null),
-          language: (mp4Muxing.filename.startsWith('audio') ? muxingWithPath.trackName : null)
+          muxingId  : mp4Muxing.id,
+          mediaFile : mp4Muxing.filename,
+          trackName : (mp4Muxing.filename.startsWith('audio') ? muxingWithPath.trackName : null),
+          language  : (mp4Muxing.filename.startsWith('audio') ? muxingWithPath.trackName : null)
         };
 
         return bitmovin.encoding.manifests.smooth(createdManifest.id).representations.mp4.add(smoothRepresentation);

--- a/examples/encoding/12_dash_manifest_vtt_subtitles.js
+++ b/examples/encoding/12_dash_manifest_vtt_subtitles.js
@@ -1,6 +1,6 @@
-const Bitmovin = require('bitmovin-javascript').default;
 const Promise  = require('bluebird');
 
+const Bitmovin = require('bitmovin-javascript').default;
 const BITMOVIN_API_KEY = '<YOUR_API_KEY>';
 const bitmovin         = new Bitmovin({'apiKey': BITMOVIN_API_KEY, debug: false});
 

--- a/examples/encoding/13_encoding_dash_hls_merged_audio_streams.js
+++ b/examples/encoding/13_encoding_dash_hls_merged_audio_streams.js
@@ -1,9 +1,8 @@
 // 13_encoding_dash_hls_merged_audio_streams.js
 
-const Bitmovin = require('bitmovin-javascript').default;
-console.log(Bitmovin);
 const Promise = require('bluebird');
 
+const Bitmovin = require('bitmovin-javascript').default;
 const BITMOVIN_API_KEY = '<INSERT_YOUR_API_CODE>';
 const bitmovin         = new Bitmovin({'apiKey': BITMOVIN_API_KEY, debug: false});
 
@@ -28,19 +27,19 @@ const OUTPUT_PATH     = '/output/bitmovin-javascript-examples/' + ENCODING_NAME 
 console.log('OUTPUT_PATH', OUTPUT_PATH);
 
 const s3Input = {
-  name       :  'Sample Input',
-  description:  'This is a demo s3 input',
-  accessKey:    S3_INPUT_ACCESS_KEY,
-  secretKey:    S3_INPUT_SECRET_KEY,
-  bucketName:   S3_INPUT_BUCKET_NAME
+  name       : 'Sample Input',
+  description: 'This is a demo s3 input',
+  accessKey  :  S3_INPUT_ACCESS_KEY,
+  secretKey  :  S3_INPUT_SECRET_KEY,
+  bucketName :  S3_INPUT_BUCKET_NAME
 };
 
 const s3Output = {
-  name       :  'S3 Output',
-  description:  'This is a demo S3 output',
-  accessKey:    S3_OUTPUT_ACCESS_KEY,
-  secretKey:    S3_OUTPUT_SECRET_KEY,
-  bucketName:   S3_OUTPUT_BUCKET_NAME
+  name       : 'S3 Output',
+  description: 'This is a demo S3 output',
+  accessKey  : S3_OUTPUT_ACCESS_KEY,
+  secretKey  : S3_OUTPUT_SECRET_KEY,
+  bucketName : S3_OUTPUT_BUCKET_NAME
 };
 
 const audioStreams = [{
@@ -100,8 +99,8 @@ const h264VideoCodecConfiguration240p = {
 };
 
 const encodingResource = {
-  name: ENCODING_NAME,
-  description: 'bitmovin-javascript api client test encoding',
+  name          : ENCODING_NAME,
+  description   : 'bitmovin-javascript api client test encoding',
   encoderVersion: 'STABLE'
 };
 
@@ -175,9 +174,9 @@ const main = () => new Promise((resolve, reject) => {
     const audioStreamPromises = Promise.map(audioStreams, audioStream => {
       const inputStreams = audioStream.inputStreams.map(inputStream => {
         const inputStreamToCreate = {
-          inputId: input.id,
-          inputPath: INPUT_FILE_PATH,
-          position: inputStream.position,
+          inputId      : input.id,
+          inputPath    : INPUT_FILE_PATH,
+          position     : inputStream.position,
           selectionMode: inputStream.selectionMode
         };
 
@@ -250,7 +249,7 @@ const main = () => new Promise((resolve, reject) => {
 
 const addAudioStreamToEncoding = (output, aacCodecConfiguration, inputStreams, encoding, language) => {
   let stream = {
-    inputStreams: inputStreams,
+    inputStreams : inputStreams,
     codecConfigId: aacCodecConfiguration.id
   };
 
@@ -267,13 +266,13 @@ const addAudioStreamToEncoding = (output, aacCodecConfiguration, inputStreams, e
 
 const addVideoStreamToEncoding = (input, output, videoCodecConfig, encoding) => {
   const inputStream = {
-    inputId: input.id,
-    inputPath: INPUT_FILE_PATH,
+    inputId      : input.id,
+    inputPath    : INPUT_FILE_PATH,
     selectionMode: 'AUTO'
   };
 
   let stream = {
-    inputStreams: [inputStream],
+    inputStreams : [inputStream],
     codecConfigId: videoCodecConfig.id
   };
 
@@ -415,14 +414,14 @@ const createHlsManifest = (output, encoding, audioMuxingsWithPath, videoMuxingsW
           const path = audioMuxingWithPath.path;
 
           const audioMedia = {
-            groupId: 'audio_group',
-            name: audioStreams[index].lang,
+            groupId    : 'audio_group',
+            name       : audioStreams[index].lang,
             segmentPath: path,
-            encodingId: encoding.id,
-            muxingId: tsMuxing.id,
-            streamId: audioMuxingWithPath.streamId,
-            language: audioStreams[index].lang,
-            uri: 'audiomedia_' + audioStreams[index].lang + '.m3u8'
+            encodingId : encoding.id,
+            muxingId   : tsMuxing.id,
+            streamId   : audioMuxingWithPath.streamId,
+            language   : audioStreams[index].lang,
+            uri        : 'audiomedia_' + audioStreams[index].lang + '.m3u8'
           };
           return bitmovin.encoding.manifests.hls(createdHlsManifest.id).media.audio.add(audioMedia);
         });
@@ -444,13 +443,13 @@ const createHlsManifest = (output, encoding, audioMuxingsWithPath, videoMuxingsW
             const uri = 'video_' + videoMuxingWithPath.path.split('/')[videoMuxingWithPath.path.split('/').length-2] + '.m3u8';
 
             const variantStream = {
-              audio: audio_group,
+              audio         : audio_group,
               closedCaptions: 'NONE',
-              segmentPath: videoMuxingWithPath.path,
-              uri: uri,
-              encodingId: encoding.id,
-              streamId: videoMuxingWithPath.streamId,
-              muxingId: videoMuxingWithPath.tsMuxing.id
+              segmentPath   : videoMuxingWithPath.path,
+              uri           : uri,
+              encodingId    : encoding.id,
+              streamId      : videoMuxingWithPath.streamId,
+              muxingId      : videoMuxingWithPath.tsMuxing.id
             };
 
             return bitmovin.encoding.manifests.hls(createdHlsManifest.id).streams.add(variantStream);
@@ -514,9 +513,9 @@ const createDashManifest = (output, encoding, audioMuxingsWithPath, videoMuxings
             const path = muxingWithPath.path;
 
             const fmp4Representation = {
-              type: 'TEMPLATE',
-              encodingId: encoding.id,
-              muxingId: fmp4Muxing.id,
+              type       : 'TEMPLATE',
+              encodingId : encoding.id,
+              muxingId   : fmp4Muxing.id,
               segmentPath: path
             };
             return bitmovin.encoding.manifests.dash(createdManifest.id).periods(createdPeriod.id)
@@ -528,9 +527,9 @@ const createDashManifest = (output, encoding, audioMuxingsWithPath, videoMuxings
               const path = muxingWithPath.path;
 
               const fmp4Representation = {
-                type: 'TEMPLATE',
-                encodingId: encoding.id,
-                muxingId: fmp4Muxing.id,
+                type       : 'TEMPLATE',
+                encodingId : encoding.id,
+                muxingId   : fmp4Muxing.id,
                 segmentPath: path
               };
 
@@ -622,8 +621,8 @@ const addStream = (encoding, stream, output, codecConfiguration, language) => {
         addTsMuxingForStream(encoding, addedStream, output, prefix).then((addedTsMuxing) => {
           const muxingWithPath = {
             fmp4Muxing: addedFmp4Muxing,
-            tsMuxing: addedTsMuxing,
-            path: prefix
+            tsMuxing  : addedTsMuxing,
+            path      : prefix
           };
           resolve([addedStream, muxingWithPath])
         });

--- a/scripts/testRunner.js
+++ b/scripts/testRunner.js
@@ -27,5 +27,4 @@ process.stdout.write = function(chunk, encoding, callback) {
   return realWrite.call(this, chunk, encoding, callback);
 };
 
-
 jest.run(argv);


### PR DESCRIPTION
-Remove some double spacing between lines
-Change export statements to single-line for consistency
-Restyle some object declarations for consistency
-Improve logic of checking for empty object
-Use value variable instead of getParams[key]
-Reorder require statements at start of encoding examples by groups