### PR TITLE
Feature/additional headers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,11 @@ module.exports = {
   },
   "extends"      : "eslint:recommended",
   "parserOptions": {
-    "sourceType": "module"
+    "sourceType"  : "module",
+    "ecmaVersion" : 6,
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true
+    }
   },
   "rules"        : {
     "accessor-pairs"               : "error",

--- a/bitmovin/bitmovin.js
+++ b/bitmovin/bitmovin.js
@@ -62,6 +62,10 @@ export default class Bitmovin {
       configuration.xApiClient = 'bitmovin-javascript';
     }
 
+    if (configuration.additionalHeaders === undefined) {
+      configuration.additionalHeaders = {};
+    }
+
     configuration.apiBaseUrl = urljoin(configuration.protocol + '://' + configuration.host, configuration.basePath);
 
     configuration.httpHeaders = {
@@ -69,7 +73,8 @@ export default class Bitmovin {
       'X-Api-Key'           : configuration.apiKey,
       'X-Tenant-Org-Id'     : configuration.tenantOrgId,
       'X-Api-Client'        : configuration.xApiClient,
-      'X-Api-Client-Version': '1.9.0'
+      'X-Api-Client-Version': '1.9.0',
+      ...configuration.additionalHeaders
     };
 
     this.configuration = configuration;

--- a/tests/bitmovin.test.js
+++ b/tests/bitmovin.test.js
@@ -21,6 +21,10 @@ describe('Bitmovin default exports', () => {
       expect(client.configuration.httpHeaders)
         .toEqual(expect.objectContaining({'X-Test-Header': 'test'}))
     })
+    it('should default additionalHeaders to {}', () => {
+      expect(new Bitmovin({apiKey}).configuration.additionalHeaders)
+        .toEqual({})
+    })
   })
   describe('encoding', () => {
     const assertItContains = (key) => {

--- a/tests/bitmovin.test.js
+++ b/tests/bitmovin.test.js
@@ -12,7 +12,7 @@ describe('Bitmovin default exports', () => {
   describe('configuration', () => {
     const emptyConfigsClient = new Bitmovin({apiKey});
     const assertItDefaults = (key, value) => {
-      it('should use default value for ' + additionalHeaders, () => {
+      it('should use default value for ' + key, () => {
         expect(emptyConfigsClient.configuration[key]).toEqual(value)
       })
     }

--- a/tests/bitmovin.test.js
+++ b/tests/bitmovin.test.js
@@ -1,12 +1,25 @@
 import Bitmovin from '../bitmovin/bitmovin'
 
 describe('Bitmovin default exports', () => {
-  const apiKey = "test-api-key";
-  const client = new Bitmovin({apiKey});
+  const apiKey = 'test-api-key';
+  const additionalHeaders = {'X-Test-Header': 'test'};
+
+  const client = new Bitmovin({
+    apiKey,
+    additionalHeaders
+  });
 
   describe('configuration', () => {
     it('should set correct ApiKey', () => {
       expect(client.configuration.apiKey).toEqual(apiKey)
+    })
+    it('should contain additionalHeaders', () => {
+      expect(client.configuration.additionalHeaders)
+        .toEqual(expect.objectContaining({'X-Test-Header': 'test'}))
+    })
+    it('should add additionalHeaders to httpHeaders', () => {
+      expect(client.configuration.httpHeaders)
+        .toEqual(expect.objectContaining({'X-Test-Header': 'test'}))
     })
   })
   describe('encoding', () => {

--- a/tests/bitmovin.test.js
+++ b/tests/bitmovin.test.js
@@ -10,6 +10,13 @@ describe('Bitmovin default exports', () => {
   });
 
   describe('configuration', () => {
+    const emptyConfigsClient = new Bitmovin({apiKey});
+    const assertItDefaults = (key, value) => {
+      it('should use default value for ' + additionalHeaders, () => {
+        expect(emptyConfigsClient.configuration[key]).toEqual(value)
+      })
+    }
+
     it('should set correct ApiKey', () => {
       expect(client.configuration.apiKey).toEqual(apiKey)
     })
@@ -21,10 +28,8 @@ describe('Bitmovin default exports', () => {
       expect(client.configuration.httpHeaders)
         .toEqual(expect.objectContaining({'X-Test-Header': 'test'}))
     })
-    it('should default additionalHeaders to {}', () => {
-      expect(new Bitmovin({apiKey}).configuration.additionalHeaders)
-        .toEqual({})
-    })
+
+    assertItDefaults('additionalHeaders', {});
   })
   describe('encoding', () => {
     const assertItContains = (key) => {


### PR DESCRIPTION
- Added `additionalHeaders` configuration option, which is merged into `httpHeaders` config
- Allow object rest spread in ESLint