### PR TITLE
Fix NPM Package Management

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bitmovin-javascript",
   "version": "2.0.0",
-  "main": "./dist/inde.js",
+  "main": "./dist/index.js",
   "browser": "./dist/bitmovin.browser.js",
   "types": "./dist/index.d.ts",
   "repository": {


### PR DESCRIPTION
Rename ./dist/inde.js to ./dist/index.js which fixes the use of
'bitmovin-javascript' as a node module VIA NPM.