### PR TITLE
Added av1 codec configuration

### DIFF
--- a/bitmovin/encoding/codecConfigurations.ts
+++ b/bitmovin/encoding/codecConfigurations.ts
@@ -50,6 +50,7 @@ export const codecConfigurations = (configuration, httpClient: HttpClient) => {
     h264: typeFn('video/h264'),
     h265: typeFn('video/h265'),
     aac: typeFn('audio/aac'),
+    av1: typeFn('video/av1'),
     vp9: typeFn('video/vp9'),
     ac3: typeFn('audio/ac3'),
     eac3: typeFn('audio/eac3'),

--- a/tests/encoding/codecConfigurations.test.ts
+++ b/tests/encoding/codecConfigurations.test.ts
@@ -132,6 +132,7 @@ describe('encoding', () => {
     testConfigType('h264', 'video/h264');
     testConfigType('h265', 'video/h265');
     testConfigType('aac', 'audio/aac');
+    testConfigType('av1', 'video/av1');
     testConfigType('vp9', 'video/vp9');
     testConfigType('ac3', 'audio/ac3');
     testConfigType('eac3', 'audio/eac3');


### PR DESCRIPTION
Issue: https://github.com/bitmovin/dashboard/issues/934
Description: There was no api call defined for AV1 encoding types. Added the type in the codec configurations.