### PR TITLE
Added getType call for encoding manifests and filters

### DIFF
--- a/bitmovin/encoding/filters.ts
+++ b/bitmovin/encoding/filters.ts
@@ -49,7 +49,12 @@ export const filters = (configuration, httpClient: HttpClient) => {
     rotate: typeFn('rotate'),
     watermark: typeFn('watermark'),
 
-    list: utils.buildListCallFunction(httpClient, configuration, urljoin(configuration.apiBaseUrl, 'encoding/filters'))
+    list: utils.buildListCallFunction(httpClient, configuration, urljoin(configuration.apiBaseUrl, 'encoding/filters')),
+    getType: filterId => {
+      const url = urljoin(configuration.apiBaseUrl, 'encoding/filters', filterId, 'type');
+
+      return get(configuration, url);
+    }
   };
 };
 

--- a/bitmovin/encoding/manifests/index.ts
+++ b/bitmovin/encoding/manifests/index.ts
@@ -8,6 +8,8 @@ import hlsManifests from './hls';
 import smoothManifests from './smooth';
 
 export const manifests = (configuration, httpClient: HttpClient) => {
+  const {get} = httpClient;
+
   return {
     list: utils.buildListCallFunction(
       httpClient,
@@ -16,7 +18,12 @@ export const manifests = (configuration, httpClient: HttpClient) => {
     ),
     dash: dashManifests(configuration),
     hls: hlsManifests(configuration),
-    smooth: smoothManifests(configuration)
+    smooth: smoothManifests(configuration),
+    getType: manifestId => {
+      const url = urljoin(configuration.apiBaseUrl, 'encoding/manifests', manifestId, 'type');
+
+      return get(configuration, url);
+    }
   };
 };
 

--- a/tests/encoding/filters.test.ts
+++ b/tests/encoding/filters.test.ts
@@ -79,6 +79,11 @@ describe('encoding', () => {
         );
         assertItReturnsUnderlyingPromise(mockGet, () => client.list(limit, offset, sort, filter));
       });
+
+      describe('getType', () => {
+        assertItCallsCorrectUrl('GET', '/v1/encoding/filters/filter-id/type', () => client.getType('filter-id'));
+        assertItReturnsUnderlyingPromise(mockGet, () => client.getType('filter-id'));
+      });
     });
 
     const testFilterType = type => {

--- a/tests/encoding/manifests.test.ts
+++ b/tests/encoding/manifests.test.ts
@@ -68,6 +68,11 @@ describe('encoding', () => {
         );
         assertItReturnsUnderlyingPromise(mockGet, () => client.list(limit, offset, sort, filter));
       });
+
+      describe('getType', () => {
+        assertItCallsCorrectUrl('GET', '/v1/encoding/manifests/manifest-id/type', () => client.getType('manifest-id'));
+        assertItReturnsUnderlyingPromise(mockGet, () => client.getType('manifest-id'));
+      });
     });
   });
 });


### PR DESCRIPTION
Issue: https://github.com/bitmovin/dashboard/issues/381
Description: Added missing `getType` call for encoding manifests and filters

Tests: Added test for the `getType` call in manifests and filters