### PR TITLE
Added list, streams, events calls to live statistics

### DIFF
--- a/bitmovin/encoding/statistics.ts
+++ b/bitmovin/encoding/statistics.ts
@@ -83,9 +83,34 @@ export const statistics = (configuration, httpClient: HttpClient) => {
           const url = urljoin(configuration.apiBaseUrl, 'encoding/statistics/encodings', encodingId);
           return get(configuration, url);
         },
-        liveStatistics: () => {
-          const url = urljoin(configuration.apiBaseUrl, 'encoding/statistics/encodings', encodingId, 'live-statistics');
-          return get(configuration, url);
+        liveStatistics: {
+          list: () => {
+            const url = urljoin(
+              configuration.apiBaseUrl,
+              'encoding/statistics/encodings',
+              encodingId,
+              'live-statistics'
+            );
+            return get(configuration, url);
+          },
+          events: () => {
+            const url = urljoin(
+              configuration.apiBaseUrl,
+              'encoding/statistics/encodings',
+              encodingId,
+              'live-statistics/events'
+            );
+            return get(configuration, url);
+          },
+          streams: () => {
+            const url = urljoin(
+              configuration.apiBaseUrl,
+              'encoding/statistics/encodings',
+              encodingId,
+              'live-statistics/streams'
+            );
+            return get(configuration, url);
+          }
         }
       };
     }

--- a/tests/encoding/statistics.test.ts
+++ b/tests/encoding/statistics.test.ts
@@ -19,11 +19,27 @@ describe('encoding', () => {
 
     describe('encodings', () => {
       describe('live-statistics', () => {
-        assertItCallsUrlAndReturnsPromise(
-          'GET',
-          '/v1/encoding/statistics/encodings/encoding-id/live-statistics',
-          client.encodings('encoding-id').liveStatistics
-        );
+        describe('list', () => {
+          assertItCallsUrlAndReturnsPromise(
+            'GET',
+            '/v1/encoding/statistics/encodings/encoding-id/live-statistics',
+            client.encodings('encoding-id').liveStatistics.list
+          );
+        });
+        describe('events', () => {
+          assertItCallsUrlAndReturnsPromise(
+            'GET',
+            '/v1/encoding/statistics/encodings/encoding-id/live-statistics/events',
+            client.encodings('encoding-id').liveStatistics.events
+          );
+        });
+        describe('streams', () => {
+          assertItCallsUrlAndReturnsPromise(
+            'GET',
+            '/v1/encoding/statistics/encodings/encoding-id/live-statistics/streams',
+            client.encodings('encoding-id').liveStatistics.streams
+          );
+        });
       });
 
       describe('vod', () => {


### PR DESCRIPTION
Issues: https://github.com/bitmovin/dashboard/issues/770
Work: Added `list`, `events` and `streams` calls to the `live-statistics`

Tests: Added tests for the `list`, `events` and `streams` calls