### PR TITLE
Support for the new /analytics/metrics endpoint

### DIFF
--- a/bitmovin/analytics/index.ts
+++ b/bitmovin/analytics/index.ts
@@ -10,8 +10,8 @@ const ANALYTICS_PATH_QUERIES = 'analytics/queries';
 const ANALYTICS_PATH_METRIC_QUERIES = 'analytics/metrics';
 
 export const enum MetricName {
-  MAX_CONCURRENTVIEWERS = 'max_concurrentviewers',
-  AVG_CONCURRENTVIEWERS = 'avg_concurrentviewers'
+  MaxConcurrentViewers = 'max_concurrentviewers',
+  AvgConcurrentViewers = 'avg_concurrentviewers'
 }
 
 export interface Analytics {

--- a/bitmovin/analytics/index.ts
+++ b/bitmovin/analytics/index.ts
@@ -1,3 +1,5 @@
+import MetricQueries from './metricQueries';
+
 import analyticsImpressions from './impressions';
 import analyticsLicenses from './licenses';
 import analyticsQueries from './queries';
@@ -5,12 +7,19 @@ import analyticsStatistics from './statistics';
 
 const ANALYTICS_PATH_QUERIES_ADS = 'analytics/ads/queries';
 const ANALYTICS_PATH_QUERIES = 'analytics/queries';
+const ANALYTICS_PATH_METRIC_QUERIES = 'analytics/metrics';
+
+export const enum MetricName {
+  MAX_CONCURRENTVIEWERS = 'max_concurrentviewers',
+  AVG_CONCURRENTVIEWERS = 'avg_concurrentviewers'
+}
 
 export interface Analytics {
   licenses: any;
   statistics: any;
   impressions: any;
   queries: any;
+  metrics: MetricQueries;
   ads: {
     queries: any;
   };
@@ -22,6 +31,7 @@ const analytics = internalConfig => ({
   ads: {
     queries: analyticsQueries(internalConfig, ANALYTICS_PATH_QUERIES_ADS)
   },
+  metrics: new MetricQueries(internalConfig, ANALYTICS_PATH_METRIC_QUERIES),
   impressions: analyticsImpressions(internalConfig),
   statistics: analyticsStatistics(internalConfig)
 });

--- a/bitmovin/analytics/metricQueries.ts
+++ b/bitmovin/analytics/metricQueries.ts
@@ -7,9 +7,9 @@ import {MetricQueryBuilder} from './metricQueryBuilder';
 
 export interface MetricQuery {
   metric: string;
-  filters: any[];
-  groupBy: any[];
-  orderBy: any[];
+  filters: Array<{name: string; operator: string; value: any}>;
+  groupBy: string[];
+  orderBy: Array<{name: string; order: string}>;
 }
 
 export default class MetricQueries {

--- a/bitmovin/analytics/metricQueries.ts
+++ b/bitmovin/analytics/metricQueries.ts
@@ -1,0 +1,33 @@
+import * as urljoin from 'url-join';
+
+import http from '../utils/http';
+import {HttpClient} from '../utils/types';
+
+import {MetricQueryBuilder} from './metricQueryBuilder';
+
+export interface MetricQuery {
+  metric: string;
+  filters: any[];
+  groupBy: any[];
+  orderBy: any[];
+}
+
+export default class MetricQueries {
+  private configuration;
+  private baseUrl: string;
+  private httpClient: HttpClient;
+
+  constructor(configuration, urlPath: string, httpClient: HttpClient = http) {
+    this.httpClient = httpClient;
+    this.configuration = configuration;
+    this.baseUrl = urljoin(configuration.apiBaseUrl, urlPath);
+  }
+
+  public metric(query: MetricQuery): Promise<{}> {
+    return this.httpClient.post(this.configuration, urljoin(this.baseUrl, query.metric), query);
+  }
+
+  get builder(): MetricQueryBuilder {
+    return new MetricQueryBuilder(this);
+  }
+}

--- a/bitmovin/analytics/metricQueryBuilder.ts
+++ b/bitmovin/analytics/metricQueryBuilder.ts
@@ -8,14 +8,12 @@ export class MetricQueryBuilder {
 
   constructor(queries: MetricQueries, query?: MetricQuery) {
     this.queries = queries;
-    this.queryObj =
-      query ||
-      Object.freeze({
-        metric: '',
-        filters: [],
-        groupBy: [],
-        orderBy: []
-      });
+    this.queryObj = query || {
+      metric: '',
+      filters: [],
+      groupBy: [],
+      orderBy: []
+    };
   }
 
   public metric(metric: MetricName | string): MetricQueryBuilder {
@@ -26,45 +24,47 @@ export class MetricQueryBuilder {
     return this.extendQuery_({start, end});
   }
 
-  public interval(interval): MetricQueryBuilder {
+  public interval(interval: string): MetricQueryBuilder {
     return this.extendQuery_({interval});
   }
 
-  public filter(name, operator, value): MetricQueryBuilder {
-    const filter = Object.freeze({name, operator, value});
-    return this.extendQuery_({filters: Object.freeze([...this.queryObj.filters, filter])});
+  public filter(name: string, operator: string, value: any): MetricQueryBuilder {
+    return this.extendQuery_({filters: [...this.queryObj.filters, {name, operator, value}]});
   }
 
-  public groupBy(dimension): MetricQueryBuilder {
-    return this.extendQuery_({groupBy: Object.freeze([...this.queryObj.groupBy, dimension])});
+  public groupBy(dimension: string): MetricQueryBuilder {
+    return this.extendQuery_({groupBy: [...this.queryObj.groupBy, dimension]});
   }
 
-  public orderBy(name, order): MetricQueryBuilder {
-    const newOrder = Object.freeze({name, order});
-    return this.extendQuery_({orderBy: Object.freeze([...this.queryObj.orderBy, newOrder])});
+  public orderBy(name: string, order: string): MetricQueryBuilder {
+    return this.extendQuery_({orderBy: [...this.queryObj.orderBy, {name, order}]});
   }
 
-  public percentile_(percentile): MetricQueryBuilder {
+  public percentile_(percentile: number): MetricQueryBuilder {
     return this.extendQuery_({percentile});
   }
 
-  public licenseKey(licenseKey): MetricQueryBuilder {
+  public licenseKey(licenseKey: string): MetricQueryBuilder {
     return this.extendQuery_({licenseKey});
   }
 
-  public limit(limit): MetricQueryBuilder {
+  public limit(limit: number): MetricQueryBuilder {
     return this.extendQuery_({limit});
   }
 
-  public offset(offset): MetricQueryBuilder {
+  public offset(offset: number): MetricQueryBuilder {
     return this.extendQuery_({offset});
   }
 
-  public extendQuery_(extensions): MetricQueryBuilder {
-    return new MetricQueryBuilder(this.queries, Object.freeze({...this.queryObj, ...extensions}));
+  public extendQuery_(extensions: any): MetricQueryBuilder {
+    return new MetricQueryBuilder(this.queries, {...this.queryObj, ...extensions});
   }
 
   public query(): Promise<{}> {
     return this.queries.metric(this.queryObj);
+  }
+
+  public queryObject(): MetricQuery {
+    return this.queryObj;
   }
 }

--- a/bitmovin/analytics/metricQueryBuilder.ts
+++ b/bitmovin/analytics/metricQueryBuilder.ts
@@ -1,0 +1,70 @@
+import MetricQueries, {MetricQuery} from './metricQueries';
+
+import {MetricName} from '.';
+
+export class MetricQueryBuilder {
+  private queryObj: MetricQuery;
+  private queries: MetricQueries;
+
+  constructor(queries: MetricQueries, query?: MetricQuery) {
+    this.queries = queries;
+    this.queryObj =
+      query ||
+      Object.freeze({
+        metric: '',
+        filters: [],
+        groupBy: [],
+        orderBy: []
+      });
+  }
+
+  public metric(metric: MetricName | string): MetricQueryBuilder {
+    return this.extendQuery_({metric});
+  }
+
+  public between(start, end): MetricQueryBuilder {
+    return this.extendQuery_({start, end});
+  }
+
+  public interval(interval): MetricQueryBuilder {
+    return this.extendQuery_({interval});
+  }
+
+  public filter(name, operator, value): MetricQueryBuilder {
+    const filter = Object.freeze({name, operator, value});
+    return this.extendQuery_({filters: Object.freeze([...this.queryObj.filters, filter])});
+  }
+
+  public groupBy(dimension): MetricQueryBuilder {
+    return this.extendQuery_({groupBy: Object.freeze([...this.queryObj.groupBy, dimension])});
+  }
+
+  public orderBy(name, order): MetricQueryBuilder {
+    const newOrder = Object.freeze({name, order});
+    return this.extendQuery_({orderBy: Object.freeze([...this.queryObj.orderBy, newOrder])});
+  }
+
+  public percentile_(percentile): MetricQueryBuilder {
+    return this.extendQuery_({percentile});
+  }
+
+  public licenseKey(licenseKey): MetricQueryBuilder {
+    return this.extendQuery_({licenseKey});
+  }
+
+  public limit(limit): MetricQueryBuilder {
+    return this.extendQuery_({limit});
+  }
+
+  public offset(offset): MetricQueryBuilder {
+    return this.extendQuery_({offset});
+  }
+
+  public extendQuery_(extensions): MetricQueryBuilder {
+    return new MetricQueryBuilder(this.queries, Object.freeze({...this.queryObj, ...extensions}));
+  }
+
+  public query(): Promise<{}> {
+    return this.queries.metric(this.queryObj);
+  }
+}


### PR DESCRIPTION
Added `analytics.metrics` and `analytics.metrics.builder` to be able to query the new API endpoint at `analytics/metrics/{metric}`.