### PR TITLE
added player/license/license_id/analytics endpoints

### DIFF
--- a/bitmovin/player/analytics.ts
+++ b/bitmovin/player/analytics.ts
@@ -4,8 +4,8 @@ import http from '../utils/http';
 import {Create, Delete, HttpClient} from '../utils/types';
 
 export interface Analytics {
-  add: Create<any>;
-  delete: Delete<any>;
+  enable: Create<any>;
+  disable: Delete<any>;
 }
 
 export const analytics = (configuration, licenseId, httpClient: HttpClient): Analytics => {
@@ -14,10 +14,10 @@ export const analytics = (configuration, licenseId, httpClient: HttpClient): Ana
   const url = urlJoin(configuration.apiBaseUrl, 'player/licenses', licenseId, 'analytics');
 
   return {
-    add: payload => {
+    enable: payload => {
       return post<any, any>(configuration, url, payload);
     },
-    delete: () => {
+    disable: () => {
       return delete_<any>(configuration, url);
     }
   };

--- a/bitmovin/player/analytics.ts
+++ b/bitmovin/player/analytics.ts
@@ -1,0 +1,28 @@
+import * as urlJoin from 'url-join';
+
+import http from '../utils/http';
+import {Create, Delete, HttpClient} from '../utils/types';
+
+export interface Analytics {
+  add: Create<any>;
+  delete: Delete<any>;
+}
+
+export const analytics = (configuration, licenseId, httpClient: HttpClient): Analytics => {
+  const {post, delete_} = httpClient;
+
+  const url = urlJoin(configuration.apiBaseUrl, 'player/licenses', licenseId, 'analytics');
+
+  return {
+    add: payload => {
+      return post<any, any>(configuration, url, payload);
+    },
+    delete: () => {
+      return delete_<any>(configuration, url);
+    }
+  };
+};
+
+export default (configuration, licenseId): Analytics => {
+  return analytics(configuration, licenseId, http);
+};

--- a/bitmovin/player/licenses.ts
+++ b/bitmovin/player/licenses.ts
@@ -3,6 +3,7 @@ import * as urljoin from 'url-join';
 import http, {utils} from '../utils/http';
 import {ApiResource, Details, HttpClient, List} from '../utils/types';
 
+import analytics, {Analytics} from './analytics';
 import domains, {Domains} from './domains';
 import thirdPartyLicensing, {ThirdPartyLicensing} from './thirdPartyLicensing';
 
@@ -43,6 +44,7 @@ export interface Licenses {
     update: (license: UpdatePlayerLicense) => Promise<ApiResource<PlayerLicense>>;
     domains: Domains;
     thirdPartyLicensing: ThirdPartyLicensing;
+    analytics: Analytics;
   };
 
   create: (licensePayload: CreatePlayerLicensePayload) => Promise<PlayerLicense>;
@@ -62,7 +64,8 @@ export const licenses = (configuration, httpClient: HttpClient): Licenses => {
         return put<PlayerLicense, PlayerLicense>(configuration, url, license);
       },
       domains: domains(configuration, licenseId),
-      thirdPartyLicensing: thirdPartyLicensing(configuration, licenseId)
+      thirdPartyLicensing: thirdPartyLicensing(configuration, licenseId),
+      analytics: analytics(configuration, licenseId)
     };
   };
 

--- a/tests/player/licenses.test.ts
+++ b/tests/player/licenses.test.ts
@@ -1,3 +1,4 @@
+import {analytics} from '../../bitmovin/player/analytics';
 import {channels} from '../../bitmovin/player/channels';
 import {domains} from '../../bitmovin/player/domains';
 import {licenses} from '../../bitmovin/player/licenses';
@@ -136,6 +137,23 @@ describe('player', () => {
         assertItCallsCorrectUrl('GET', '/v1/player/channels/stable/versions/latest', client('stable').versions.latest);
         assertItReturnsUnderlyingPromise(mockGet, client('stable').versions.latest);
       });
+    });
+  });
+
+  describe('analytics', () => {
+    const licenseId = 'somePlayerLicenseId';
+    const client = analytics(testConfiguration, licenseId, mockHttp);
+
+    describe('add', () => {
+      const payload = {analyticsKey: 'someAnalyticsKey'};
+      assertItCallsCorrectUrl('POST', '/v1/player/licenses/' + licenseId + '/analytics', client.add);
+      assertItReturnsUnderlyingPromise(mockPost, () => client.add(payload));
+      assertPayload(mockPost, () => client.add(payload), payload);
+    });
+
+    describe('delete', () => {
+      assertItCallsCorrectUrl('DELETE', '/v1/player/licenses/' + licenseId + '/analytics', client.delete);
+      assertItReturnsUnderlyingPromise(mockGet, client.delete);
     });
   });
 });

--- a/tests/player/licenses.test.ts
+++ b/tests/player/licenses.test.ts
@@ -144,16 +144,16 @@ describe('player', () => {
     const licenseId = 'somePlayerLicenseId';
     const client = analytics(testConfiguration, licenseId, mockHttp);
 
-    describe('add', () => {
+    describe('enable', () => {
       const payload = {analyticsKey: 'someAnalyticsKey'};
-      assertItCallsCorrectUrl('POST', '/v1/player/licenses/' + licenseId + '/analytics', client.add);
-      assertItReturnsUnderlyingPromise(mockPost, () => client.add(payload));
-      assertPayload(mockPost, () => client.add(payload), payload);
+      assertItCallsCorrectUrl('POST', '/v1/player/licenses/' + licenseId + '/analytics', client.enable);
+      assertItReturnsUnderlyingPromise(mockPost, () => client.enable(payload));
+      assertPayload(mockPost, () => client.enable(payload), payload);
     });
 
-    describe('delete', () => {
-      assertItCallsCorrectUrl('DELETE', '/v1/player/licenses/' + licenseId + '/analytics', client.delete);
-      assertItReturnsUnderlyingPromise(mockGet, client.delete);
+    describe('disable', () => {
+      assertItCallsCorrectUrl('DELETE', '/v1/player/licenses/' + licenseId + '/analytics', client.disable);
+      assertItReturnsUnderlyingPromise(mockGet, client.disable);
     });
   });
 });


### PR DESCRIPTION
related to [#2083](https://github.com/bitmovin/dashboard/issues/2083)

added `player/licenses/[license_id]/analytics` `create` and `delete` endpoints