### PR TITLE
Feature/add sub orgs endpoints

### DIFF
--- a/bitmovin/account/organizations/index.ts
+++ b/bitmovin/account/organizations/index.ts
@@ -4,6 +4,7 @@ import http from '../../utils/http';
 import {HttpClient} from '../../utils/types';
 
 import groups from './groups';
+import subOrganizations from './sub-organizations';
 
 export const organizations = (configuration, httpClient: HttpClient) => {
   const {get, post, delete_, put} = httpClient;
@@ -23,7 +24,8 @@ export const organizations = (configuration, httpClient: HttpClient) => {
         const url = urljoin(organizationsBaseUrl, organizationId);
         return put(configuration, url, organization);
       },
-      groups: groups(configuration, organizationId)
+      groups: groups(configuration, organizationId),
+      subOrganizations: subOrganizations(configuration, organizationId)
     };
   };
 

--- a/bitmovin/account/organizations/sub-organizations.ts
+++ b/bitmovin/account/organizations/sub-organizations.ts
@@ -1,0 +1,27 @@
+import * as urljoin from 'url-join';
+
+import http from '../../utils/http';
+import {HttpClient} from '../../utils/types';
+
+export const subOrganizations = (configuration, organizationId, httpClient: HttpClient) => {
+  const {get} = httpClient;
+  const subOrganizationBaseUrl = urljoin(
+    configuration.apiBaseUrl,
+    'account',
+    'organizations',
+    organizationId,
+    'sub-organizations'
+  );
+
+  const list = () => {
+    const url = urljoin(subOrganizationBaseUrl);
+    return get(configuration, url);
+  };
+
+  const resource = Object.assign({list});
+  return resource;
+};
+
+export default (configuration, organizationId) => {
+  return subOrganizations(configuration, organizationId, http);
+};

--- a/tests/account/organizations/sub-organizations.test.ts
+++ b/tests/account/organizations/sub-organizations.test.ts
@@ -1,0 +1,32 @@
+import * as urljoin from 'url-join';
+
+import {subOrganizations} from '../../../bitmovin/account/organizations/sub-organizations';
+import {
+  assertItCallsCorrectUrl,
+  assertItReturnsUnderlyingPromise,
+  mockGet,
+  mockHttp,
+  testSetup
+} from '../../assertions';
+
+import {getConfiguration} from '../../utils';
+const testConfiguration = getConfiguration();
+
+describe('account', () => {
+  beforeEach(testSetup);
+  describe('organizations', () => {
+    describe('sub-organizations', () => {
+      const testOrgId = '123';
+      const client = subOrganizations(testConfiguration, testOrgId, mockHttp);
+
+      describe('list', () => {
+        assertItCallsCorrectUrl(
+          'GET',
+          urljoin('/v1/account/organizations', testOrgId, 'sub-organizations'),
+          client.list
+        );
+        assertItReturnsUnderlyingPromise(mockGet, client.list);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Related to: [#2464](https://github.com/bitmovin/dashboard/issues/2464)

work: Added sub Organizations endPoints

> SHOULD NOT BE MERGED BEFORE https://github.com/bitmovin/bitmovin-open-api/pull/386 is merged