### PR TITLE
AN-967 Impressions endpoint

### DIFF
--- a/bitmovin/analytics/impressions.ts
+++ b/bitmovin/analytics/impressions.ts
@@ -3,7 +3,7 @@ import * as urljoin from 'url-join';
 import http from '../utils/http';
 import {HttpClient} from '../utils/types';
 
-export interface ImpressionDetailsQuery {
+export interface ImpressionsQuery {
   licenseKey: string;
   start: number;
   end: number;
@@ -18,7 +18,7 @@ export const impressions = (configuration, httpClient: HttpClient) => {
     const url = urljoin(impressionsBaseUrl, impressionId);
     return post(configuration, url, {licenseKey});
   };
-  const list = (query: ImpressionDetailsQuery) => {
+  const list = (query: ImpressionsQuery) => {
     const url = impressionsBaseUrl;
     return post(configuration, url, query);
   };

--- a/bitmovin/analytics/impressions.ts
+++ b/bitmovin/analytics/impressions.ts
@@ -3,6 +3,13 @@ import * as urljoin from 'url-join';
 import http from '../utils/http';
 import {HttpClient} from '../utils/types';
 
+export interface ImpressionDetailsQuery {
+  licenseKey: string;
+  start: number;
+  end: number;
+  filters?: Array<{name: string; operator: string; value: any}>;
+}
+
 export const impressions = (configuration, httpClient: HttpClient) => {
   const {post} = httpClient;
   const impressionsBaseUrl = urljoin(configuration.apiBaseUrl, 'analytics', 'impressions');
@@ -11,20 +18,9 @@ export const impressions = (configuration, httpClient: HttpClient) => {
     const url = urljoin(impressionsBaseUrl, impressionId);
     return post(configuration, url, {licenseKey});
   };
-  const list = (
-    licenseKey: string,
-    startTime: number,
-    endTime: number,
-    filters?: Array<{name: string; operator: string; value: any}>
-  ) => {
+  const list = (query: ImpressionDetailsQuery) => {
     const url = impressionsBaseUrl;
-    const payload = {
-      licenseKey,
-      start: startTime,
-      end: endTime,
-      filters
-    };
-    return post(configuration, url, payload);
+    return post(configuration, url, query);
   };
 
   const resource = Object.assign(list, {details});

--- a/bitmovin/analytics/impressions.ts
+++ b/bitmovin/analytics/impressions.ts
@@ -5,14 +5,30 @@ import {HttpClient} from '../utils/types';
 
 export const impressions = (configuration, httpClient: HttpClient) => {
   const {post} = httpClient;
-  const impressionBaseUrl = urljoin(configuration.apiBaseUrl, 'analytics', 'impressions');
+  const impressionsBaseUrl = urljoin(configuration.apiBaseUrl, 'analytics', 'impressions');
 
-  const fn = (impressionId, licenseKey) => {
-    const url = urljoin(impressionBaseUrl, impressionId);
+  const details = (impressionId: string, licenseKey: string) => {
+    const url = urljoin(impressionsBaseUrl, impressionId);
     return post(configuration, url, {licenseKey});
   };
+  const list = (
+    licenseKey: string,
+    startTime: number,
+    endTime: number,
+    filters?: Array<{name: string; operator: string; value: any}>
+  ) => {
+    const url = impressionsBaseUrl;
+    const payload = {
+      licenseKey,
+      start: startTime,
+      end: endTime,
+      filters
+    };
+    return post(configuration, url, payload);
+  };
 
-  return fn;
+  const resource = Object.assign(list, {details});
+  return resource;
 };
 
 export default configuration => {

--- a/examples/analytics/03_impressions.js
+++ b/examples/analytics/03_impressions.js
@@ -4,12 +4,13 @@ console.log(Bitmovin);
 const BITMOVIN_API_KEY = '<YOUR API KEY>';
 const bitmovin = new Bitmovin({apiKey: BITMOVIN_API_KEY, debug: false});
 
-const startTime = new Date('2019-11-07').getTime();
-const endTime = new Date('2019-11-10').getTime();
-const filters = [{name: 'CUSTOM_USER_ID', operator: 'EQ', value: 'customer#1'}];
-
 bitmovin.analytics
-  .impressions('<YOUR ANALYTICS LICENSE KEY>', startTime, endTime, filters)
+  .impressions({
+    licenseKey: '<YOUR ANALYTICS LICENSE KEY>',
+    start: new Date('2019-11-07').getTime(),
+    end: new Date('2019-11-10').getTime(),
+    filters: [{name: 'CUSTOM_USER_ID', operator: 'EQ', value: 'customer#1'}]
+  })
   .then(result => {
     console.log(result);
   })

--- a/examples/analytics/03_impressions.js
+++ b/examples/analytics/03_impressions.js
@@ -1,0 +1,27 @@
+const Bitmovin = require('../../dist/index').default;
+console.log(Bitmovin);
+
+const BITMOVIN_API_KEY = '<YOUR API KEY>';
+const bitmovin = new Bitmovin({apiKey: BITMOVIN_API_KEY, debug: false});
+
+const startTime = new Date('2019-11-07').getTime();
+const endTime = new Date('2019-11-10').getTime();
+const filters = [{name: 'CUSTOM_USER_ID', operator: 'EQ', value: 'customer#1'}];
+
+bitmovin.analytics
+  .impressions('<YOUR ANALYTICS LICENSE KEY>', startTime, endTime, filters)
+  .then(result => {
+    console.log(result);
+  })
+  .catch(error => {
+    console.error('Error fetching impressions', error);
+  });
+
+bitmovin.analytics.impressions
+  .details('<IMPRESSION ID>', '<YOUR ANALYTICS LICENSE KEY>')
+  .then(result => {
+    console.log(result);
+  })
+  .catch(error => {
+    console.error('Error getting impression details', error);
+  });

--- a/tests/analytics/impressions.test.ts
+++ b/tests/analytics/impressions.test.ts
@@ -36,13 +36,15 @@ describe('analytics', () => {
   describe('impressions', () => {
     const start = 1573137000000;
     const end = 1573396200000;
-    assertItCallsCorrectUrl('POST', '/v1/analytics/impressions', () => impressionsClient('license-key', start, end));
-    assertItReturnsUnderlyingPromise(mockPost, () => impressionsClient('license-key', start, end));
+    assertItCallsCorrectUrl('POST', '/v1/analytics/impressions', () =>
+      impressionsClient({licenseKey: 'license-key', start, end})
+    );
+    assertItReturnsUnderlyingPromise(mockPost, () => impressionsClient({licenseKey: 'license-key', start, end}));
     assertPayload(
       mockPost,
       () => {
         const filters = [{name: 'CUSTOM_USER_ID', operator: 'EQ', value: 'customer#1'}];
-        return impressionsClient('license-key', start, end, filters);
+        return impressionsClient({licenseKey: 'license-key', start, end, filters});
       },
       {
         licenseKey: 'license-key',

--- a/tests/analytics/impressions.test.ts
+++ b/tests/analytics/impressions.test.ts
@@ -15,19 +15,41 @@ describe('analytics', () => {
   beforeEach(testSetup);
   const impressionsClient = impressions(testConfiguration, mockHttp);
 
-  describe('impressions', () => {
+  describe('impression details', () => {
     assertItCallsCorrectUrl('POST', '/v1/analytics/impressions/my-impression-id', () =>
-      impressionsClient('my-impression-id', 'license-key')
+      impressionsClient.details('my-impression-id', 'license-key')
     );
-    assertItReturnsUnderlyingPromise(mockPost, () => impressionsClient('my-impression-id', 'license-key'));
-    assertPayload(mockPost, () => impressionsClient('my-impression-id', 'license-key'), {licenseKey: 'license-key'});
+    assertItReturnsUnderlyingPromise(mockPost, () => impressionsClient.details('my-impression-id', 'license-key'));
+    assertPayload(mockPost, () => impressionsClient.details('my-impression-id', 'license-key'), {
+      licenseKey: 'license-key'
+    });
 
     describe('without license key', () => {
       assertItCallsCorrectUrl('POST', '/v1/analytics/impressions/my-impression-id', () =>
-        impressionsClient('my-impression-id', undefined)
+        impressionsClient.details('my-impression-id', undefined)
       );
-      assertItReturnsUnderlyingPromise(mockPost, () => impressionsClient('my-impression-id', undefined));
-      assertPayload(mockPost, () => impressionsClient('my-impression-id', undefined), {licenseKey: undefined});
+      assertItReturnsUnderlyingPromise(mockPost, () => impressionsClient.details('my-impression-id', undefined));
+      assertPayload(mockPost, () => impressionsClient.details('my-impression-id', undefined), {licenseKey: undefined});
     });
+  });
+
+  describe('impressions', () => {
+    const start = 1573137000000;
+    const end = 1573396200000;
+    assertItCallsCorrectUrl('POST', '/v1/analytics/impressions', () => impressionsClient('license-key', start, end));
+    assertItReturnsUnderlyingPromise(mockPost, () => impressionsClient('license-key', start, end));
+    assertPayload(
+      mockPost,
+      () => {
+        const filters = [{name: 'CUSTOM_USER_ID', operator: 'EQ', value: 'customer#1'}];
+        return impressionsClient('license-key', start, end, filters);
+      },
+      {
+        licenseKey: 'license-key',
+        start: 1573137000000,
+        end: 1573396200000,
+        filters: [{name: 'CUSTOM_USER_ID', operator: 'EQ', value: 'customer#1'}]
+      }
+    );
   });
 });


### PR DESCRIPTION
Issue: https://bitmovin.atlassian.net/browse/AN-967

Work: Modified the analytics `impressions` endpoint:
- `analytics.impressions` is a new endpoint to query impressions
- `analytics.impressions.details` is the 'old' endpoint to query details of a specific impression