### PR TITLE
feature/remove-source-maps

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/dubnium

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "moduleResolution": "node",
-    "sourceMap": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "removeComments": false,


### PR DESCRIPTION
# Work
Remove "sourceMap": true to not produce warnings in customers projects
- warnings were found in Dahboard project using standard CRA v5
- add .nvmrc with node v10, so developers know what to use for yarn install

Warnings produced when library  `bitmovin-javascript@2.34.0` is used (can be easy reproduced with create-react-app v5)
<img width="1677" alt="Screenshot 2022-07-28 at 13 23 21" src="https://user-images.githubusercontent.com/3775835/181494599-ff35fdf3-f3b9-494b-a9db-63d29abb0d13.png">


> Will be released after PR is merged as `2.35.0` (current `2.34.0`, released 2y ago)

