### PR TITLE
feat: remove UMD dependencies from project to support modern build tools

### DIFF
--- a/bitmovin/utils/http.ts
+++ b/bitmovin/utils/http.ts
@@ -1,4 +1,3 @@
-import 'es6-promise/auto';
 import * as fetch from 'isomorphic-fetch';
 import * as urljoin from 'url-join';
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitmovin-javascript",
-  "version": "2.36.0",
+  "version": "2.35.0",
   "main": "./dist/index.js",
   "browser": "./dist/bitmovin.browser.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitmovin-javascript",
-  "version": "2.35.0",
+  "version": "2.36.0",
   "main": "./dist/index.js",
   "browser": "./dist/bitmovin.browser.js",
   "types": "./dist/index.d.ts",
@@ -63,9 +63,8 @@
     "webpack-cli": "^3.1.1"
   },
   "dependencies": {
-    "es6-promise": "^4.2.4",
     "isomorphic-fetch": "^2.2.1",
     "moment": "^2.17.1",
-    "url-join": "^1.1.0"
+    "url-join": "3"
   }
 }

--- a/tests/assertions.ts
+++ b/tests/assertions.ts
@@ -1,5 +1,3 @@
-import {Promise} from 'es6-promise';
-
 export const mockGet = jest.fn().mockReturnValue(Promise.resolve({}));
 export const mockPost = jest.fn().mockReturnValue(Promise.resolve({}));
 export const mockDelete = jest.fn().mockReturnValue(Promise.resolve({}));

--- a/tests/utils/http.test.ts
+++ b/tests/utils/http.test.ts
@@ -1,5 +1,3 @@
-import {Promise} from 'es6-promise';
-
 import http from '../../bitmovin/utils/http';
 import {InternalConfiguration} from '../../bitmovin/utils/types';
 import {getConfiguration} from '../utils';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1947,11 +1947,6 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
 
-es6-promise@^4.2.4:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
-  integrity sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==
-
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -6572,10 +6567,10 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-url-join@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/url-join/-/url-join-1.1.0.tgz#741c6c2f4596c4830d6718460920d0c92202dc78"
-  integrity sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=
+url-join@3:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-3.0.0.tgz#26e8113ace195ea30d0fc38186e45400f9cea672"
+  integrity sha512-HPK12oY2BUzZDsenkms5LNC+Uger4o8jAuZbH5sLA6oKEbJqjKlo9v4o6loiSnNNQMmEZ8dDt60hX71J1G122A==
 
 url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
Issue: to unblock usage of modern tools, like Vite v6+, that do not support UMD format anymore

Work:

feat: remove UMD dependencies from project to support modern build tools
- `es6-promise` as polyfill was removed
- `url-join` was upgraded to v3 that comes CommonJs format